### PR TITLE
Fix broken links in footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,7 +52,7 @@ module.exports = {
           items: [
             {
               label: "Maintained by Frontside",
-              href: "https://fronside.com/",
+              href: "https://fronstide.com/",
             },
           ]
         },
@@ -61,7 +61,7 @@ module.exports = {
           items: [
             {
               label: "Interactors",
-              href: "https://frontside.com/effection",
+              href: "https://frontside.com/interactors",
             },
             {
               label: "Bigtest",


### PR DESCRIPTION
- typo: "fronside.com" -> "frontside.com"
- Interactors link was pointing to https://frontside.com/effection